### PR TITLE
add `validators` directory to installation files.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     #py_modules=['flask_validator'],
     # if you would be using a package instead use packages instead
     # of py_modules:
-    packages=['flask_validator'],
+    packages=['flask_validator', 'flask_validator.validators'],
     zip_safe=False,
     include_package_data=True,
     platforms='any',


### PR DESCRIPTION
with using this installation command: pip install git+git://github.com/adekoder/flask-validator.git#egg=flask-validator, validators module doesn't appear on the installed folder and it requires to copy it manually.
